### PR TITLE
Fix gun damage affix

### DIFF
--- a/src/main/resources/data/fallen_gems_affixes/affixes/gun/attribute/bullet_damage.json
+++ b/src/main/resources/data/fallen_gems_affixes/affixes/gun/attribute/bullet_damage.json
@@ -1,6 +1,6 @@
 {
   "type": "apotheosis:attribute",
-  "attribute": "scguns:additional_bullet_damage",
+  "attribute": "scguns:bullet_damage_multiplier",
   "operation": "MULTIPLY_BASE",
   "values": {
     "common": {


### PR DESCRIPTION
The default value for `"scguns:additional_bullet_damage"` is `0.0`, which means the multiplicative effect from the affix does nothing. Instead, you should use `"scguns:bullet_damage_multiplier"`, which has a default value of `1.0` and properly multiplies.